### PR TITLE
0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,18 @@ requirements:
     - maturin 1.3.0
   run:
     - python
+  run_constrained:
+    - numpy >= 1.21.6
+    - tensorflow >= 2.11
+    - jax >= 0.3.25
+    - jaxlib >= 0.3.25
+    - flax >= 0.6.3
 
 test:
   source_files:
     # Excluded test modules:
     # test_flax_comparison.py: Missing flax on defaults
-    # test_paddle_comparison.py: Missing paddle on defaults
+    # test_paddle_comparison.py: Missing paddlepaddle on defaults
     # test_tf_comparison.py: Adding tensorflow causes pip check to fail
     - bindings/python/tests/data
     - bindings/python/tests/test_pt_comparison.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
     - wheel
     - maturin 1.3.0
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - setuptools
     - setuptools-rust
     - wheel
+    - maturin 1.3.0
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,31 @@ requirements:
     - python
 
 test:
+  source_files:
+    # Excluded test modules:
+    # test_flax_comparison.py: Missing flax on defaults
+    # test_paddle_comparison.py: Missing paddle on defaults
+    # test_tf_comparison.py: Adding tensorflow causes pip check to fail
+    - bindings/python/tests/data
+    - bindings/python/tests/test_pt_comparison.py
+    - bindings/python/tests/test_pt_model.py
+    - bindings/python/tests/test_simple.py
   imports:
     - safetensors
   requires:
     - pip
+    - numpy
+    - h5py >= 3.7.0
+    - huggingface_hub >= 0.12.1
+    - setuptools-rust >= 1.5.2
+    - pytest >= 7.2.0
+    - pytest-benchmark >= 4.0.0
+    - hypothesis >= 6.70.2
+    - pytorch >= 1.10
   commands:
     - pip check
+    - cd bindings/python
+    - pytest tests
 
 about:
   home: https://github.com/huggingface/safetensors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,22 +33,11 @@ requirements:
     - flax >= 0.6.3
 
 test:
-# Skip tests on ppc64le/python 3.11; missing pytorch.
-{% if not (ppc64le and py>310) %}
-  source_files:
-    # Excluded test modules:
-    # test_flax_comparison.py: Missing flax on defaults
-    # test_paddle_comparison.py: Missing paddlepaddle on defaults
-    # test_tf_comparison.py: Adding tensorflow causes pip check to fail
-    - bindings/python/tests/data
-    - bindings/python/tests/test_pt_comparison.py
-    - bindings/python/tests/test_pt_model.py
-    - bindings/python/tests/test_simple.py
-{% endif %}
   imports:
     - safetensors
   requires:
     - pip
+# Skip tests on ppc64le/python 3.11; missing pytorch.
 {% if not (ppc64le and py>310) %}
     - numpy
     - h5py >= 3.7.0
@@ -58,11 +47,17 @@ test:
     - pytest-benchmark >= 4.0.0
     - hypothesis >= 6.70.2
     - pytorch >= 1.10
+  source_files:
+    - bindings/python/tests
 {% endif %}
   commands:
     - pip check
+    # Excluded test modules:
+    # test_flax_comparison.py: Missing flax on defaults
+    # test_paddle_comparison.py: Missing paddlepaddle on defaults
+    # test_tf_comparison.py: Adding tensorflow causes pip check to fail
     - cd bindings/python  # [not (ppc64le and py>310)]
-    - pytest tests  # [not (ppc64le and py>310)]
+    - pytest -v tests --ignore=tests/test_tf_comparison.py --ignore=tests/test_paddle_comparison.py --ignore=tests/test_flax_comparison.py  # [not (ppc64le and py>310)]
 
 about:
   home: https://github.com/huggingface/safetensors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  missing_dso_whitelist:  # [s390x]
-    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - flax >= 0.6.3
 
 test:
+# Skip tests on ppc64le/python 3.11; missing pytorch.
+{% if not (ppc64le and py>310) %}
   source_files:
     # Excluded test modules:
     # test_flax_comparison.py: Missing flax on defaults
@@ -43,10 +45,12 @@ test:
     - bindings/python/tests/test_pt_comparison.py
     - bindings/python/tests/test_pt_model.py
     - bindings/python/tests/test_simple.py
+{% endif %}
   imports:
     - safetensors
   requires:
     - pip
+{% if not (ppc64le and py>310) %}
     - numpy
     - h5py >= 3.7.0
     - huggingface_hub >= 0.12.1
@@ -55,10 +59,11 @@ test:
     - pytest-benchmark >= 4.0.0
     - hypothesis >= 6.70.2
     - pytorch >= 1.10
+{% endif %}
   commands:
     - pip check
-    - cd bindings/python
-    - pytest tests
+    - cd bindings/python  # [not (ppc64le and py>310)]
+    - pytest tests  # [not (ppc64le and py>310)]
 
 about:
   home: https://github.com/huggingface/safetensors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - pip
     - python
     - setuptools
-    - setuptools-rust
     - wheel
     - maturin 1.3.0
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "safetensors" %}
-{% set version = "0.3.2" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2dbd34554ed3b99435a0e84df077108f5334c8336b5ed9cb8b6b98f7b10da2f6
+  sha256: b985953c3cf11e942eac4317ef3db3da713e274109cf7cfb6076d877054f013e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
 
 build:
   number: 0
-  # 2023/8/23: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename, and testing one of them fails but another succeeded.
-  skip: True  # [py<37 or s390x or (win and (rust_compiler == 'rust-gnu'))]
+  skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   missing_dso_whitelist:  # [s390x]
     - '$RPATH/ld64.so.1'  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # 2023/8/23: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename, and testing one of them fails but another succeeded.
-  skip: True  # [py<37 or (win and (rust_compiler == 'rust-gnu'))]
+  skip: True  # [py<37 or s390x or (win and (rust_compiler == 'rust-gnu'))]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   missing_dso_whitelist:  # [s390x]
     - '$RPATH/ld64.so.1'  # [s390x]


### PR DESCRIPTION
[Upstream repo](https://github.com/huggingface/safetensors)

- Added `maturin`. Disabled s390x build as `maturin` is missing from that platform.
- Added test suite