### PR TITLE
PKG-5552: Update Safetensors dependency to 0.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 1
   skip: True  # [py<38]
+  skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   host:
     - pip
     - python
-    - wheel
     - maturin >=1.0,<2.0
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "safetensors" %}
-{% set version = "0.4.2" %}
+{% set version = "0.4.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: acc85dcb09ec5e8aa787f588d7ad4d55c103f31e4ff060e17d92cc0e8b8cac73
+  sha256: 5fe3e9b705250d0172ed4e100a811543108653fb2b66b9e702a088ad03772a07
 build:
   number: 1
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 5fe3e9b705250d0172ed4e100a811543108653fb2b66b9e702a088ad03772a07
 build:
-  number: 1
+  number: 0
   skip: True  # [py<38]
   skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5fe3e9b705250d0172ed4e100a811543108653fb2b66b9e702a088ad03772a07
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<37]
   skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,6 @@ test:
     - safetensors
   requires:
     - pip
-# Skip tests on ppc64le/python 3.11; missing pytorch.
-{% if not (ppc64le and py>310) %}
     - numpy
     - h5py >=3.7.0
     - huggingface_hub >=0.12.1
@@ -50,7 +48,6 @@ test:
     - pytorch >=1.10
   source_files:
     - bindings/python/tests
-{% endif %}
   commands:
     - pip check
     # Excluded test modules:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 build:
   number: 1
   skip: True  # [py<38]
-  skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,7 +21,7 @@ requirements:
     - pip
     - python
     - wheel
-    - maturin 1.3.0
+    - maturin >=1.0,<2.0
   run:
     - python
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 5fe3e9b705250d0172ed4e100a811543108653fb2b66b9e702a088ad03772a07
 build:
   number: 1
-  skip: True  # [py<38 and s390x]
+  skip: True  # [py<38]
+  skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5fe3e9b705250d0172ed4e100a811543108653fb2b66b9e702a088ad03772a07
 build:
   number: 1
-  skip: True  # [py<38]
+  skip: True  # [py<38 and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
safetensors 0.4.4

**Destination channel:** defaults

### Links

- [PKG-5552](https://anaconda.atlassian.net/browse/PKG-5552) 
- [Upstream repository](https://github.com/huggingface/safetensors)
- [Upstream changelog/diff](https://github.com/huggingface/safetensors/releases)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/accelerate-feedstock/pull/5

### Explanation of changes:

- Update safetensors to 0.4.4 - it is a dependency of the llama-cpp-scripts / llama.cpp packaging work.
- Remove the s390x skip as the issue may now be fixed, and lack of an updated build blocks the PR above 


[PKG-5552]: https://anaconda.atlassian.net/browse/PKG-5552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ