### PR TITLE
v0.5.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "safetensors" %}
-{% set version = "0.4.5" %}
+{% set version = "0.5.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,9 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d73de19682deabb02524b3d5d1f8b3aaba94c72f1bbfc7911b9b9d5d391c0310
+  sha256: b6b0d6ecacec39a4fdd99cc19f4576f5219ce858e6fd8dbe7609df0b8dc56965
 build:
-  number: 1
+  number: 0
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   missing_dso_whitelist:  # [linux and s390x]


### PR DESCRIPTION
safetensors v0.5.3

**Destination channel:** defaults

### Links

- [PKG-6515](https://anaconda.atlassian.net/browse/PKG-6515) 
- [Upstream repository](https://github.com/huggingface/safetensors/tree/v0.5.3)


### Explanation of changes:

- Bump version and SHA
- Reset build number
- Build for python 3.13


[PKG-6515]: https://anaconda.atlassian.net/browse/PKG-6515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ